### PR TITLE
Fix the default tmp dir (fixes a few tests)

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -42,7 +42,7 @@ function _getTMPDir() {
   }
 
   // fallback to the default
-  return '/tmp';
+  return '/tmp/';
 }
 
 /**


### PR DESCRIPTION
Hiya,

I noticed the tests weren't completely working so I've fixed the default /tmp dir (should be /tmp/) since otherwise files of names /tmpclike-oX4RWS-postfix were failing to be created - should have been /tmp/clike-oX4RWS-postfix.

Cheers,
Andy
