### PR TITLE
Only add uncaughtException listener when API methods are called

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -153,6 +153,7 @@ function _getTmpName(options, callback) {
  */
 function _createTmpFile(options, callback) {
   var
+    listener = _startCatching(),
     args = _parseArguments(options, callback),
     opts = args[0],
     cb = args[1];
@@ -161,15 +162,22 @@ function _createTmpFile(options, callback) {
 
   // gets a temporary filename
   _getTmpName(opts, function _tmpNameCreated(err, name) {
-    if (err) return cb(err);
+    if (err) {
+      cb(err);
+      return _stopCatching(listener);
+    }
 
     // create and open the file
     fs.open(name, _c.O_CREAT | _c.O_EXCL | _c.O_RDWR, opts.mode || 0600, function _fileCreated(err, fd) {
-      if (err) return cb(err);
+      if (err) {
+        cb(err);
+        return _stopCatching(listener);
+      }
 
       if (!opts.keep) _removeObjects.unshift([ fs.unlinkSync, name ]);
 
       cb(null, name, fd);
+      _stopCatching(listener);
     });
   });
 }
@@ -205,17 +213,24 @@ function _rmdirRecursiveSync(dir) {
  */
 function _createTmpDir(options, callback) {
   var
+    listener = _startCatching(),
     args = _parseArguments(options, callback),
     opts = args[0],
     cb = args[1];
 
   // gets a temporary filename
   _getTmpName(opts, function _tmpNameCreated(err, name) {
-    if (err) return cb(err);
+    if (err) {
+      cb(err);
+      return _stopCatching(listener);
+    }
 
     // create the directory
     fs.mkdir(name, opts.mode || 0700, function _dirCreated(err) {
-      if (err) return cb(err);
+      if (err) {
+        cb(err);
+        return _stopCatching(listener);
+      }
 
       if (!opts.keep) {
         if (opts.unsafeCleanup) {
@@ -226,6 +241,7 @@ function _createTmpDir(options, callback) {
       }
 
       cb(null, name);
+      _stopCatching(listener);
     });
   });
 }
@@ -253,12 +269,20 @@ function _setGracefulCleanup() {
   _gracefulCleanup = true;
 }
 
-process.addListener('uncaughtException', function _uncaughtExceptionThrown( err ) {
-  _uncaughtException = true;
-  _garbageCollector();
+function _startCatching() {
+  function uncaughtExceptionListener(err) {
+    _uncaughtException = true;
+    _garbageCollector();
 
-  throw err;
-});
+    throw err;
+  }
+  process.addListener('uncaughtException', uncaughtExceptionListener);
+  return uncaughtExceptionListener;
+}
+
+function _stopCatching(listener) {
+  process.removeListener('uncaughtException', listener);
+}
 
 process.addListener('exit', function _exit() {
   _garbageCollector();


### PR DESCRIPTION
Instead of adding the `uncaughtException` listener whenever the `tmp.js` module is required, the listener could be registered when one of the exported methods are used.  Listeners could then be unregistered after API method callbacks are called.

Without this change, `tmp.js` is [frequently attributed](https://www.google.com/search?q=tmp.js+error) as the source of uncaught errors.
