### PR TITLE
Rethrow only on node v0.8.

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -258,7 +258,7 @@ process.addListener('uncaughtException', function _uncaughtExceptionThrown( err 
   _uncaughtException = true;
   _garbageCollector();
 
-  if (process.versions.node.indexOf('0.8') >= 0)
+  if (process.versions.node.indexOf('0.8') == 0)
     throw err;
 });
 


### PR DESCRIPTION
This pull-request uses `process.versions.node` to detect if we are on node v0.8 and **only** in that case we rethrow after the `'uncaughtException'` handler.
This solves the problem in #14 in a much simpler way.
