### PR TITLE
If we are not on node 0.8, don't register an uncaughtException handler

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -254,7 +254,11 @@ function _setGracefulCleanup() {
   _gracefulCleanup = true;
 }
 
-if (process.versions.node.indexOf('0.8') == 0) {
+var version = process.versions.node.split('.').map(function (value) {
+  return parseInt(value, 10);
+});
+
+if (version[0] === 0 && (version[1] < 9 || version[1] === 9 && version[2] < 5)) {
   process.addListener('uncaughtException', function _uncaughtExceptionThrown( err ) {
     _uncaughtException = true;
     _garbageCollector();


### PR DESCRIPTION
An even better solution for #14, #19. If there is an unhandled exception in node 0.10 the `exit` event will be fired with a non-zero `code` parameter. We can use this rather than handling `uncaughtException`.
