### PR TITLE
Fix for #36

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -250,10 +250,11 @@ function _createTmpDir(options, callback) {
     fs.mkdir(name, opts.mode || 0700, function _dirCreated(err) {
       if (err) return cb(err);
 
-      var removeCallback = _prepareRemoveCallback(
-        opts.unsafeCleanup
-          ? _rmdirRecursiveSync
-          : fs.rmdirSync.bind(fs),
+      var removeCallback = _prepareRemoveCallback(function () {
+          opts.unsafeCleanup
+            ? _rmdirRecursiveSync(name)
+            : fs.rmdirSync(name)
+        },
         name
       );
 


### PR DESCRIPTION
- fixes #36:_createTmpDir _removeCallback was improperly configured

Also fixes in part #31. Some files and one tmp dir will remain. I believe that this might be related to the spawn sub process tests or those that use templates or fixed names.