### PR TITLE
use `os.tmpdir()` polyfill for more consistent behaviour

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -12,11 +12,10 @@
 var
   fs     = require('fs'),
   path   = require('path'),
-  os     = require('os'),
   crypto = require('crypto'),
   exists = fs.exists || path.exists,
   existsSync = fs.existsSync || path.existsSync,
-  tmpDir = os.tmpDir || _getTMPDir,
+  tmpDir = require('os-tmpdir'),
   _c     = require('constants');
 
 
@@ -70,25 +69,6 @@ function _randomChars(howMany) {
   }
 
   return value.join('');
-}
-
-/**
- * Gets the temp directory.
- *
- * @return {String}
- * @api private
- */
-function _getTMPDir() {
-  var tmpNames = ['TMPDIR', 'TMP', 'TEMP'];
-
-  for (var i = 0, length = tmpNames.length; i < length; i++) {
-    if (_isUndefined(process.env[tmpNames[i]])) continue;
-
-    return process.env[tmpNames[i]];
-  }
-
-  // fallback to the default
-  return '/tmp';
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "node": ">=0.4.0"
   },
 
-  "dependencies": {},
+  "dependencies": {
+    "os-tmpdir": "~1.0.0"
+  },
 
   "devDependencies": {
     "vows": "~0.7.0"


### PR DESCRIPTION
The `os.tmpdir()` method has changed a lot between Node versions and it would be nice for users if it were consistent between Node versions. This might even prevent hard to track down bugs. It also has the added benefit of removing some code, which is always good.

Node 0.10.38: https://github.com/joyent/node/blob/0b5731a63cc40c4fe9275c79158fe0a5dd4d1609/lib/os.js#L44-L49

io.js 2.0.1: https://github.com/iojs/io.js/blob/6c80e38b014b7be570ffafa91032a6d67d7dd4ae/lib/os.js#L25-L40

From io.js changelog:

> os.tmpdir() is now cross-platform consistent and will no longer returns a path with a trailling slash on any platform

> Updated os.tmpdir on Windows to use the %SystemRoot% or %WINDIR% environment variables instead of the hard-coded value of c:\windows when determining the temporary directory location.

---

https://github.com/sindresorhus/os-tmpdir