### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
   "homepage": "http://github.com/raszi/node-tmp",
   "keywords": [ "temporary", "tmp", "temp", "tempdir", "tempfile", "tmpdir", "tmpfile" ],
 
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://opensource.org/licenses/MIT"
-    }
-  ],
+  "license": "MIT",
 
   "repository": {
     "type": "git",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/