### PR TITLE
fix duplicate delete for _rmdirRecursiveSync

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -271,8 +271,10 @@ function _rmdirRecursiveSync(root) {
         stat = fs.lstatSync(file); // lstat so we don't recurse into symlinked directories
 
       if (stat.isDirectory()) {
-        canRemove = false;
-        dirs.push(dir);
+        if (canRemove === true) {
+          canRemove = false;
+          dirs.push(dir);
+        }
         dirs.push(file);
       } else {
         fs.unlinkSync(file);


### PR DESCRIPTION
Duplicate PR as https://github.com/raszi/node-tmp/pull/63 , but that PR is frozen.

This is a very critical matter, so I made this.