### PR TITLE
Fixed invalid variable name in error handling

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -352,7 +352,7 @@ function _prepareTmpFileRemoveCallback(name, fd, opts) {
       // under some node/windows related circumstances, a temporary file
       // may have not be created as expected or the file was already closed
       // by the user, in which case we will simply ignore the error
-      if (e.errno != -_c.EBADF && e.errno != -_c.ENOENT) {
+      if (e.errno != _c.EBADF && e.errno != _c.ENOENT) {
         // reraise any unanticipated error
         throw e;
       }

--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -274,7 +274,7 @@ function _rmdirRecursiveSync(root) {
         if (!deferred) {
           deferred = true;
           dirs.push(dir);
-        }  
+        }
         dirs.push(file);
       } else {
         fs.unlinkSync(file);
@@ -349,10 +349,10 @@ function _prepareTmpFileRemoveCallback(name, fd, opts) {
       fs.closeSync(fdPath[0]);
     }
     catch (e) {
-      // under some node/windows related circumstances, a temporary file 
+      // under some node/windows related circumstances, a temporary file
       // may have not be created as expected or the file was already closed
       // by the user, in which case we will simply ignore the error
-      if (e.errno != -_c.EBADF && e.errno != -c.ENOENT) {
+      if (e.errno != -_c.EBADF && e.errno != -_c.ENOENT) {
         // reraise any unanticipated error
         throw e;
       }


### PR DESCRIPTION
Fixed invalid variable reference
My IDE also auto-fixed trailing spaces in two places.
