### PR TITLE
Prune `_removeObjects` correctly

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -400,7 +400,7 @@ function _prepareRemoveCallback(removeFunction, arg) {
   return function _cleanupCallback() {
     if (called) return;
 
-    var index = _removeObjects.indexOf(removeFunction);
+    var index = _removeObjects.indexOf(_cleanupCallback);
     if (index >= 0) {
       _removeObjects.splice(index, 1);
     }


### PR DESCRIPTION
We are pushing the `_cleanupCallback` wrapper into `_removeObjects`,
not the original `removeFunction`.

---------

I'm very unfamiliar with vows.js, so I'm submitting this without a test case - sorry! Inserting some `console.log` debug statements indicates that it fixes the problem though.