### PR TITLE
Replace calls to deprecated fs API functions

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -13,8 +13,6 @@ var
   fs     = require('fs'),
   path   = require('path'),
   crypto = require('crypto'),
-  exists = fs.exists || path.exists,
-  existsSync = fs.existsSync || path.existsSync,
   tmpDir = require('os-tmpdir'),
   _c     = require('constants');
 
@@ -156,8 +154,8 @@ function _getTmpName(options, callback) {
     var name = _generateTmpName(opts);
 
     // check whether the path exists then retry if needed
-    exists(name, function _pathExists(pathExists) {
-      if (pathExists) {
+    fs.stat(name, function (err) {
+      if (!err) {
         if (tries-- > 0) return _getUniqueName();
 
         return cb(new Error('Could not get a unique tmp filename, max tries reached ' + name));
@@ -189,8 +187,10 @@ function _getTmpNameSync(options) {
 
   do {
     var name = _generateTmpName(opts);
-    if (!existsSync(name)) {
-      return name;
+    try {
+        fs.statSync(name);
+    } catch (e) {
+        return name;
     }
   } while (tries-- > 0);
 


### PR DESCRIPTION
Use fs.stat() and fs.statSync() instead of deprecated fs.exists()
and fs.existsSync().