### PR TITLE
inline constants to avoid problem with node 6.x

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -15,9 +15,15 @@ var
   crypto = require('crypto'),
   exists = fs.exists || path.exists,
   existsSync = fs.existsSync || path.existsSync,
-  tmpDir = require('os-tmpdir'),
-  _c     = require('constants');
+  tmpDir = require('os-tmpdir');
 
+// can't use require('constants').
+// since node 6.x this is under process.binding('constants').fs
+var O_CREAT = 512,
+    O_EXCL  = 2048,
+    O_RDWR  = 2,
+    EBADF   = 9,
+    ENOENT  = 2;
 
 /**
  * The working inner variables.
@@ -33,7 +39,7 @@ var
 
   DEFAULT_TRIES = 3,
 
-  CREATE_FLAGS = _c.O_CREAT | _c.O_EXCL | _c.O_RDWR,
+  CREATE_FLAGS = O_CREAT | O_EXCL | O_RDWR,
 
   DIR_MODE = 448 /* 0700 */,
   FILE_MODE = 384 /* 0600 */,
@@ -351,7 +357,7 @@ function _prepareTmpFileRemoveCallback(name, fd, opts) {
       // under some node/windows related circumstances, a temporary file 
       // may have not be created as expected or the file was already closed
       // by the user, in which case we will simply ignore the error
-      if (e.errno != -_c.EBADF && e.errno != -_c.ENOENT) {
+      if (e.errno != -EBADF && e.errno != -ENOENT) {
         // reraise any unanticipated error
         throw e;
       }


### PR DESCRIPTION
On node 6.5.0 I can't find the constants using `require('constants')`. I can find them using `process.binding('constants').os.errno` and `process.binding('constants').fs`.

By inlining the constants, we can be back- and forwards compatible.