### PR TITLE
add options to control descriptor management

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -221,7 +221,19 @@ function _createTmpFile(options, callback) {
       if (err) return cb(err);
 
       if (opts.discardDescriptor) {
-        return fs.close(fd, function _invokeCallback(err) {
+        return fs.close(fd, function _discardCallback(err) {
+          if (err) {
+            // Low probability, and the file exists, so this could be
+            // ignored.  If it isn't we certainly need to unlink the
+            // file, and if that fails too its error is more
+            // important.
+            try {
+              fs.unlinkSync(name);
+            } catch (e) {
+              err = e;
+            }
+            return cb(err);
+          }
           cb(null, name, undefined, _prepareTmpFileRemoveCallback(name, -1, opts));
         });
       }

--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -220,6 +220,14 @@ function _createTmpFile(options, callback) {
     fs.open(name, CREATE_FLAGS, opts.mode || FILE_MODE, function _fileCreated(err, fd) {
       if (err) return cb(err);
 
+      if (opts.discardDescriptor) {
+        return fs.close(fd, function _invokeCallback(err) {
+          cb(null, name, undefined, _prepareTmpFileRemoveCallback(name, -1, opts));
+        });
+      }
+      if (opts.detachDescriptor) {
+        return cb(null, name, fd, _prepareTmpFileRemoveCallback(name, -1, opts));
+      }
       cb(null, name, fd, _prepareTmpFileRemoveCallback(name, fd, opts));
     });
   });
@@ -345,7 +353,9 @@ function _createTmpDirSync(options) {
 function _prepareTmpFileRemoveCallback(name, fd, opts) {
   var removeCallback = _prepareRemoveCallback(function _removeCallback(fdPath) {
     try {
-      fs.closeSync(fdPath[0]);
+      if (0 <= fdPath[0]) {
+        fs.closeSync(fdPath[0]);
+      }
     }
     catch (e) {
       // under some node/windows related circumstances, a temporary file

--- a/test/base.js
+++ b/test/base.js
@@ -86,6 +86,10 @@ function _testGracefulSync(type, graceful, cb) {
   _spawnTestWithoutError('graceful-sync.js', [ type, graceful ], cb);
 }
 
+function _assertNoDescriptor(err, name, fd) {
+  assert.strictEqual(fd, undefined);
+}
+
 function _assertName(err, name) {
   assert.isString(name);
   assert.isNotZero(name.length, 'an empty string is not a valid name');
@@ -141,6 +145,7 @@ module.exports.testGraceful = _testGraceful;
 module.exports.testGracefulSync = _testGracefulSync;
 module.exports.assertName = _assertName;
 module.exports.assertNameSync = _assertNameSync;
+module.exports.assertNoDescriptor = _assertNoDescriptor;
 module.exports.testName = _testName;
 module.exports.testNameSync = _testNameSync;
 module.exports.testUnsafeCleanup = _testUnsafeCleanup;


### PR DESCRIPTION
This is a proposed implementation supporting issue #88 and providing a solution to the problem identified in issue #91.  This works on Linux.  I'm unable to test on Windows, and am unsure whether it behaves the same as POSIX systems when a descriptor is kept open after the file is removed.

Let me know if you find this worthwhile, or would like changes made before merging.

Thanks in advance for considering this.
