### PR TITLE
Fix for garbage collector, issue #97

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -419,9 +419,11 @@ function _garbageCollector() {
     return;
   }
 
-  for (var i = 0, length = _removeObjects.length; i < length; i++) {
+  // the function being called removes itself from _removeObjects,
+  // loop until _removeObjects is empty
+  while(_removeObjects.length) {
     try {
-      _removeObjects[i].call(null);
+      _removeObjects[0].call(null);
     } catch (e) {
       // already removed?
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":        "tmp",
-  "version":     "0.0.29",
+  "version":     "0.0.30",
   "description": "Temporary file and directory creator",
   "author":      "KARASZI István <github@spam.raszi.hu> (http://raszi.hu/)",
 


### PR DESCRIPTION
Changed the way how _removeObjects is being looped in function _garbageCollector, each function in the array should be called once (keeping in mind the fact that the function itself modifies _removeObjects array).

Writing a test case for reproducing the problem, and checking the correct behavior is somewhat difficult, because the carbage collection is being run only at process exit. No test cases were added/changed, because that would require significant changes to how the test cases are being run.