### PR TITLE
fix #57

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -421,16 +421,17 @@ function _prepareTmpDirRemoveCallback(name, opts) {
 function _prepareRemoveCallback(removeFunction, arg) {
   var called = false;
 
-  return function _cleanupCallback() {
-    if (called) return;
+  return function _cleanupCallback(next) {
+    if (!called) {
+        var index = _removeObjects.indexOf(_cleanupCallback);
+        if (index >= 0) {
+          _removeObjects.splice(index, 1);
+        }
 
-    var index = _removeObjects.indexOf(_cleanupCallback);
-    if (index >= 0) {
-      _removeObjects.splice(index, 1);
+        called = true;
+        removeFunction(arg);
     }
-
-    called = true;
-    removeFunction(arg);
+    if (next) next(null);
   };
 }
 


### PR DESCRIPTION
Adds ability to pass a next callback to the clean up callback in order to leverage the use of tmp in combionation with async and other such tools.

This is still WIP and required tests are still missing.