### PR TITLE
Only add process handlers if graceful cleanup requested

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -510,26 +510,29 @@ function isExpectedError(error, code, errno) {
  * Also removes the created files and directories when an uncaught exception occurs.
  */
 function setGracefulCleanup() {
+  if (_gracefulCleanup) {
+    return;
+  }
   _gracefulCleanup = true;
-}
 
-const version = process.versions.node.split('.').map(function (value) {
-  return parseInt(value, 10);
-});
+  const version = process.versions.node.split('.').map(function (value) {
+    return parseInt(value, 10);
+  });
 
-if (version[0] === 0 && (version[1] < 9 || version[1] === 9 && version[2] < 5)) {
-  process.addListener('uncaughtException', function _uncaughtExceptionThrown(err) {
-    _uncaughtException = true;
+  if (version[0] === 0 && (version[1] < 9 || version[1] === 9 && version[2] < 5)) {
+    process.addListener('uncaughtException', function _uncaughtExceptionThrown(err) {
+      _uncaughtException = true;
+      _garbageCollector();
+
+      throw err;
+    });
+  }
+
+  process.addListener('exit', function _exit(code) {
+    if (code) _uncaughtException = true;
     _garbageCollector();
-
-    throw err;
   });
 }
-
-process.addListener('exit', function _exit(code) {
-  if (code) _uncaughtException = true;
-  _garbageCollector();
-});
 
 /**
  * Configuration options.


### PR DESCRIPTION
I was running into MaxListenersExceededWarning when running Jest tests which referenced this module. I'm new to the project but after a quick look I think the change is safe.