### PR TITLE
Avoid relying on Node’s internals

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -10,10 +10,13 @@
  * Module dependencies.
  */
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 const osTmpDir = require('os-tmpdir');
-const _c = process.binding('constants');
+const _c = fs.constants && os.constants ?
+  { fs: fs.constants, os: os.constants } :
+  process.binding('constants');
 
 /*
  * The working inner variables.
@@ -289,7 +292,7 @@ function fileSync(options) {
   var fd = fs.openSync(name, CREATE_FLAGS, opts.mode || FILE_MODE);
   /* istanbul ignore else */
   if (opts.discardDescriptor) {
-    fs.closeSync(fd); 
+    fs.closeSync(fd);
     fd = undefined;
   }
 


### PR DESCRIPTION
`process.binding()` is an internal API of Node, and
its use should be avoided.

Modern versions of Node have `constants` properties
on the individual public modules, so using these
and falling back to the `process.binding()` path
ensures that this module is unaffected by
changes to Node’s internals.