### PR TITLE
Add `unsafeCleanup` option to jsdoc

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -600,6 +600,7 @@ _safely_install_listener();
  * @property {?string} dir the tmp directory to use
  * @property {?string} prefix prefix for the generated name
  * @property {?string} postfix postfix for the generated name
+ * @property {?boolean} unsafeCleanup recursively removes the created temporary directory, even when it's not empty
  */
 
 /**


### PR DESCRIPTION
IDEs like WebStorm/IntelliJ supports jsdoc blocks to add ability to code completion and typechecking.
Thus, the missing `unsafeCleanup` option in jsdoc forces the IDE to highlight the `tmp.dir({ unsafeCleanup: true }, ...)` calls as an error.
