### PR TITLE
fix #182 fileSync takes empty string postfix option

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -285,7 +285,7 @@ function fileSync(options) {
     args = _parseArguments(options),
     opts = args[0];
 
-  opts.postfix = opts.postfix || '.tmp';
+  opts.postfix = (_isUndefined(opts.postfix)) ? '.tmp' : opts.postfix;
 
   const discardOrDetachDescriptor = opts.discardDescriptor || opts.detachDescriptor;
   const name = tmpNameSync(opts);


### PR DESCRIPTION
`{postfix :""}` gives filename without file extension.