### PR TITLE
fix #214: refactor tests and lib

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -377,7 +377,7 @@ function _removeFileAsync(fdPath, next) {
   };
 
   if (0 <= fdPath[0])
-    fs.close(fdPath[0], function (err) {
+    fs.close(fdPath[0], function () {
       fs.unlink(fdPath[1], _handler);
     });
   else fs.unlink(fdPath[1], _handler);
@@ -390,6 +390,7 @@ function _removeFileAsync(fdPath, next) {
  * @private
  */
 function _removeFileSync(fdPath) {
+  var rethrownException = null;
   try {
     if (0 <= fdPath[0]) fs.closeSync(fdPath[0]);
   } catch (e) {
@@ -401,8 +402,11 @@ function _removeFileSync(fdPath) {
     }
     catch (e) {
       // reraise any unanticipated error
-      if (!isENOENT(e)) throw e;
+      if (!isENOENT(e)) rethrownException = e;
     }
+  }
+  if (rethrownException !== null) {
+    throw rethrownException;
   }
 }
 

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -24,9 +24,9 @@ module.exports.assertMode = function assertMode(name, mode) {
   // “other” bits then. Ignore execute bit on that platform because it
   // doesn’t exist—even for directories.
   if (process.platform == 'win32') {
-    assert.equal(stat.mode & 000600, mode & 000600);
+    assert.equal(stat.mode & 0o600, mode & 0o600);
   } else {
-    assert.equal(stat.mode & 000777, mode);
+    assert.equal(stat.mode & 0o777, mode);
   }
 };
 

--- a/test/child-process.js
+++ b/test/child-process.js
@@ -50,6 +50,7 @@ function _doSpawn(commandArgs, cb, signal) {
   child.stdin.end();
 
   function _close() {
+    // prevent race conditions
     if (stderrDone && stdoutDone && !done) {
       const
         stderr = _bufferConcat(stderrBufs).toString(),

--- a/test/dir-test.js
+++ b/test/dir-test.js
@@ -3,7 +3,6 @@
 
 var
   assert = require('assert'),
-  fs = require('fs'),
   path = require('path'),
   inbandStandardTests = require('./inband-standard'),
   childProcess = require('./child-process').genericChildProcess,

--- a/test/file-test.js
+++ b/test/file-test.js
@@ -3,7 +3,6 @@
 
 var
   assert = require('assert'),
-  fs = require('fs'),
   inbandStandardTests = require('./inband-standard'),
   assertions = require('./assertions'),
   childProcess = require('./child-process').genericChildProcess,

--- a/test/inband-standard.js
+++ b/test/inband-standard.js
@@ -2,7 +2,6 @@
 // vim: expandtab:ts=2:sw=2
 
 var
-  assert = require('assert'),
   path = require('path'),
   assertions = require('./assertions'),
   rimraf = require('rimraf'),
@@ -80,6 +79,7 @@ function inbandStandardTests(testOpts, opts, isFile, beforeHook, sync = false) {
           try {
             rimraf.sync(this.topic.name);
           } catch (_ignored) {
+            // ignore
           }
           throw err;
         }

--- a/test/issue121-test.js
+++ b/test/issue121-test.js
@@ -5,7 +5,6 @@ const
   assertions = require('./assertions'),
   childProcess = require('./child-process').childProcess,
   os = require('os'),
-  rimraf = require('rimraf'),
   testCases = [
     'SIGINT',
     'SIGTERM'
@@ -27,7 +26,7 @@ describe('tmp', function () {
   });
 });
 
-function issue121Tests(signal, expectExists) {
+function issue121Tests(signal) {
   return function (done) {
     childProcess(this, 'issue121.json', function (err, stderr, stdout) {
       if (err) return done(err);

--- a/test/outband/issue121.js
+++ b/test/outband/issue121.js
@@ -1,8 +1,6 @@
-/* eslint-disable no-octal */
 // vim: expandtab:ts=2:sw=2
 
-const
-  tmp = require('../../lib/tmp');
+const tmp = require('../../lib/tmp');
 
 process.on('SIGTERM', function () {
   process.exit(0);

--- a/test/outband/issue129-sigint.js
+++ b/test/outband/issue129-sigint.js
@@ -9,7 +9,7 @@ module.exports = function () {
 
   // simulate an existing SIGINT listener
   process.addListener('SIGINT', function _tmp$sigint_listener() {
-      self.out('EOK');
+    self.out('EOK');
   });
 
   // now let tmp install its listener safely


### PR DESCRIPTION
only tmp- prefixed names must be used
remove unused imports
fix linting problems
fix octal number literals
add missing comments