### PR TITLE
fix #230: regression after fix for #197

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -45,7 +45,8 @@ const
   _removeObjects = [],
 
   // API change in fs.rmdirSync leads to error when passing in a second parameter, e.g. the callback
-  FN_RMDIR_SYNC = fs.rmdirSync.bind(fs);
+  FN_RMDIR_SYNC = fs.rmdirSync.bind(fs),
+  FN_RIMRAF_SYNC = rimraf.sync;
 
 var
   _gracefulCleanup = false;
@@ -433,31 +434,6 @@ function _prepareTmpFileRemoveCallback(name, fd, opts, sync) {
 }
 
 /**
- * Simple wrapper for rimraf.
- *
- * @param {string} dirPath
- * @param {Function} next
- * @private
- */
-function _rimrafRemoveDirWrapper(dirPath, next) {
-  rimraf(dirPath, next);
-}
-
-/**
- * Simple wrapper for rimraf.sync.
- *
- * @param {string} dirPath
- * @private
- */
-function _rimrafRemoveDirSyncWrapper(dirPath, next) {
-  try {
-    return next(null, rimraf.sync(dirPath));
-  } catch (err) {
-    return next(err);
-  }
-}
-
-/**
  * Prepares the callback for removal of the temporary directory.
  *
  * Returns either a sync callback or a async callback depending on whether
@@ -470,8 +446,8 @@ function _rimrafRemoveDirSyncWrapper(dirPath, next) {
  * @private
  */
 function _prepareTmpDirRemoveCallback(name, opts, sync) {
-  const removeFunction = opts.unsafeCleanup ? _rimrafRemoveDirWrapper : fs.rmdir.bind(fs);
-  const removeFunctionSync = opts.unsafeCleanup ? _rimrafRemoveDirSyncWrapper : FN_RMDIR_SYNC;
+  const removeFunction = opts.unsafeCleanup ? rimraf : fs.rmdir.bind(fs);
+  const removeFunctionSync = opts.unsafeCleanup ? FN_RIMRAF_SYNC : FN_RMDIR_SYNC;
   const removeCallbackSync = _prepareRemoveCallback(removeFunctionSync, name, sync);
   const removeCallback = _prepareRemoveCallback(removeFunction, name, sync, removeCallbackSync);
   if (!opts.keep) _removeObjects.unshift(removeCallbackSync);
@@ -507,7 +483,7 @@ function _prepareRemoveCallback(removeFunction, fileOrDirName, sync, cleanupCall
       if (index >= 0) _removeObjects.splice(index, 1);
 
       called = true;
-      if (sync || removeFunction === FN_RMDIR_SYNC) {
+      if (sync || removeFunction === FN_RMDIR_SYNC || removeFunction == FN_RIMRAF_SYNC) {
         return removeFunction(fileOrDirName);
       } else {
         return removeFunction(fileOrDirName, next || function() {});


### PR DESCRIPTION
- must call either rimraf.sync or rmdirSync during garbage collection and not use a next parameter
- remove rimraf wrappers, one can directly call the functions and the wrappers do not make any sense