### PR TITLE
[refactor to typescript] Refactor code to work on Win

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -341,7 +341,6 @@ export interface AsyncInterface {
  *
  * @public
  * @interface
- * 
  * @category Interfaces / Sync
  */
 export interface SyncInterface {

--- a/src/internal/Configuration.ts
+++ b/src/internal/Configuration.ts
@@ -33,7 +33,7 @@ export default class Configuration {
     public readonly tries: number;
     public readonly length: number;
 
-    private readonly _resolvedDir: string;
+    public readonly _resolvedDir: string;
 
     public readonly fileFlags: string = Configuration.DEFAULT_FILE_FLAGS;
 
@@ -43,7 +43,9 @@ export default class Configuration {
         const dir = PathUtils.normalize(options.dir);
         if (!StringUtils.isBlank(dir)) {
             this._resolvedDir = PathUtils.resolvePath(dir, this.tmpdir);
-            this.dir = PathUtils.makeRelative(this._resolvedDir, this.tmpdir);
+            const relativeDir = PathUtils.makeRelative(this._resolvedDir, this.tmpdir);
+            if(typeof relativeDir==='string') this.dir = relativeDir;
+            else throw new Error(`configured dir '${this._resolvedDir}' must be relative to '${this.tmpdir}'.`);
         } else {
             this.dir = '';
         }
@@ -75,9 +77,6 @@ export default class Configuration {
         const dirIsNotBlank = !StringUtils.isBlank(this.dir);
         if (dirIsNotBlank && !PathUtils.exists(PathUtils.resolvePath(this.dir, this.tmpdir))) {
             throw new Error(`configured dir '${this.dir}' does not exist.`);
-        }
-        if (dirIsNotBlank && !PathUtils.isRelative(this.dir, this.tmpdir)) {
-            throw new Error(`configured dir '${this.dir}' must be relative to '${this.tmpdir}'.`);
         }
         // TODO: assert is dir is actually a directory
         if (PathUtils.containsPathSeparator(this.template)) {

--- a/src/internal/Configuration.ts
+++ b/src/internal/Configuration.ts
@@ -33,7 +33,7 @@ export default class Configuration {
     public readonly tries: number;
     public readonly length: number;
 
-    public readonly _resolvedDir: string;
+    private readonly _resolvedDir: string;
 
     public readonly fileFlags: string = Configuration.DEFAULT_FILE_FLAGS;
 

--- a/src/internal/PathUtils.ts
+++ b/src/internal/PathUtils.ts
@@ -5,8 +5,6 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-const IS_WIN32 = os.platform() === 'win32';
-
 export default class PathUtils {
 
     public static isRelative(name: string, root: string): boolean {

--- a/test/TestUtils.js
+++ b/test/TestUtils.js
@@ -40,6 +40,7 @@ class TestUtils {
     }
     static createTempFile(name) {
         if (!fs.existsSync(name)) {
+            // FIXME: Fails SOMETIMES on windows with error ENOENT: no such file or directory
             const fd = fs.openSync(this.qualifiedPath(name), Configuration_1.default.DEFAULT_FILE_FLAGS, Configuration_1.default.DEFAULT_FILE_MODE);
             fs.closeSync(fd);
         }

--- a/test/internal/AsyncObjectCreatorTestSuite.ts
+++ b/test/internal/AsyncObjectCreatorTestSuite.ts
@@ -33,6 +33,7 @@ class AsyncObjectCreatorTestSuite {
         this.sut.createFile(oname, oconfiguration, (err, result) => {
             try {
                 assert.equal(result.name, oname);
+                // FIXME: Results of TestUtils.fileExists are inconsistent in windows env. Maybe an async issue?
                 assert.ok(TestUtils.fileExists(result.name));
                 assert.ok(typeof result.dispose === 'function');
                 return result.dispose(() => {

--- a/test/internal/ConfigurationTestSuite.ts
+++ b/test/internal/ConfigurationTestSuite.ts
@@ -6,6 +6,7 @@ import * as os from 'os';
 
 import {suite, test} from '@testdeck/jest';
 import * as assert from 'assert';
+import PathUtils from '../../src/internal/PathUtils';
 
 @suite
 class ConfigurationTestSuite {
@@ -85,12 +86,21 @@ class ConfigurationTestSuite {
         });
     }
 
+	// it seems this tests usecase is to make sure, access to dirs outside of temp dir is rejected??
+	// "TryingToEscape" is misleading, could also be escaped slashes. Fixed name.
+	// TODO: Better function name
     @test
-    public validationMustFailOnDirTryingToEscapeRootTmpDir() {
+    public validationMustFailOnDirTryingToLeaveRootTmpDir() {
         assert.throws(() => {
             const _ = new Configuration({
                 dir: TestUtils.nativePath(['..', 'etc'])
             });
+            const normalizedDir = PathUtils.normalize(TestUtils.nativePath(['..', 'etc']));
+            console.log(TestUtils.nativePath(['..', 'etc']));
+            console.log('normalizedDir',normalizedDir);
+            console.log('tmpDir',_.tmpdir);
+            console.log('resolvedDir',_._resolvedDir);
+            console.log('dir',_.dir);
         });
     }
 

--- a/test/internal/ConfigurationTestSuite.ts
+++ b/test/internal/ConfigurationTestSuite.ts
@@ -6,7 +6,6 @@ import * as os from 'os';
 
 import {suite, test} from '@testdeck/jest';
 import * as assert from 'assert';
-import PathUtils from '../../src/internal/PathUtils';
 
 @suite
 class ConfigurationTestSuite {
@@ -92,12 +91,6 @@ class ConfigurationTestSuite {
             const _ = new Configuration({
                 dir: TestUtils.nativePath(['..', 'etc'])
             });
-            const normalizedDir = PathUtils.normalize(TestUtils.nativePath(['..', 'etc']));
-            console.log(TestUtils.nativePath(['..', 'etc']));
-            console.log('normalizedDir',normalizedDir);
-            console.log('tmpDir',_.tmpdir);
-            console.log('resolvedDir',_._resolvedDir);
-            console.log('dir',_.dir);
         });
     }
 

--- a/test/internal/ConfigurationTestSuite.ts
+++ b/test/internal/ConfigurationTestSuite.ts
@@ -86,9 +86,6 @@ class ConfigurationTestSuite {
         });
     }
 
-	// it seems this tests usecase is to make sure, access to dirs outside of temp dir is rejected??
-	// "TryingToEscape" is misleading, could also be escaped slashes. Fixed name.
-	// TODO: Better function name
     @test
     public validationMustFailOnDirTryingToLeaveRootTmpDir() {
         assert.throws(() => {

--- a/test/internal/PathUtilsTestSuite.ts
+++ b/test/internal/PathUtilsTestSuite.ts
@@ -3,6 +3,7 @@ import PathUtils from '../../src/internal/PathUtils';
 import TestUtils from '../TestUtils';
 
 import * as os from 'os';
+import * as path from 'path';
 
 import {suite, test} from '@testdeck/jest';
 import * as assert from 'assert';
@@ -35,14 +36,16 @@ class PathUtilsTestSuite {
 
     @test
     public normalize() {
+        // normalize uses path.sep so comparing to static values will fail depending on platform.
+        // expect slashes to be converted to correct ones platform-specific.
         assert.equal(PathUtils.normalize(undefined), '');
         assert.equal(PathUtils.normalize(null), '');
         assert.equal(PathUtils.normalize(''), '');
         assert.equal(PathUtils.normalize(' '), '');
         assert.equal(PathUtils.normalize('\'foo\''), 'foo');
         assert.equal(PathUtils.normalize('\"foo\"'), 'foo');
-        assert.equal(PathUtils.normalize('\\\\foo\\\\bar'), '\\foo\\bar');
-        assert.equal(PathUtils.normalize('//foo//bar'), '/foo/bar');
+        assert.equal(PathUtils.normalize('\\\\foo\\\\bar'), path.sep+'foo'+path.sep+'bar');
+        assert.equal(PathUtils.normalize('//foo//bar'), path.sep+'foo'+path.sep+'bar');
     }
 
     @test


### PR DESCRIPTION
looking into node-tmp I found the in-progress typescript refactoring branch by @silkentrance and decided this would be the best starting point for my own needs. I did a little work on code to fix tests failing on windows:

* PathUtils.normalize was not behaving correctly when passing an absolute Windows file path e.g. C:\stuff
* PathUtils.normalize test fix: normalize uses path.sep for joining the components. The test comparision was using hardcoded fwd slashes. Updated to use path.sep too.
* PathUtils.makeRelative was returning empty string if path was not relative, returns false now
* This made the relative path enforcement fail before. Validation checks explicitly for false now