### PR TITLE
fix #268: Revert "fix #246: remove any double quotes or single quotes…

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -535,7 +535,7 @@ function _assertAndSanitizeOptions(options) {
   options.template = _isBlank(options.template) ? undefined : path.relative(options.dir, options.template);
 
   // for completeness' sake only, also keep (multiple) blanks if the user, purportedly sane, requests us to
-  options.name = _isUndefined(options.name) ? undefined : _sanitizeName(options.name);
+  options.name = _isUndefined(options.name) ? undefined : options.name;
   options.prefix = _isUndefined(options.prefix) ? '' : options.prefix;
   options.postfix = _isUndefined(options.postfix) ? '' : options.postfix;
 }
@@ -552,26 +552,11 @@ function _assertAndSanitizeOptions(options) {
  * @private
  */
 function _resolvePath(name, tmpDir) {
-  const sanitizedName = _sanitizeName(name);
-  if (sanitizedName.startsWith(tmpDir)) {
-    return path.resolve(sanitizedName);
+  if (name.startsWith(tmpDir)) {
+    return path.resolve(name);
   } else {
-    return path.resolve(path.join(tmpDir, sanitizedName));
+    return path.resolve(path.join(tmpDir, name));
   }
-}
-
-/**
- * Sanitize the specified path name by removing all quote characters.
- *
- * @param name
- * @returns {string}
- * @private
- */
-function _sanitizeName(name) {
-  if (_isBlank(name)) {
-    return name;
-  }
-  return name.replace(/["']/g, '');
 }
 
 /**
@@ -663,7 +648,7 @@ function setGracefulCleanup() {
  * @returns {string} the currently configured tmp dir
  */
 function _getTmpDir(options) {
-  return path.resolve(_sanitizeName(options && options.tmpdir || os.tmpdir()));
+  return path.resolve(options && options.tmpdir || os.tmpdir());
 }
 
 // Install process exit listener

--- a/test/name-sync-test.js
+++ b/test/name-sync-test.js
@@ -4,9 +4,11 @@
 const
   assert = require('assert'),
   os = require('os'),
+  path = require('path'),
   inbandStandardTests = require('./name-inband-standard'),
   tmp = require('../lib/tmp');
 
+const isWindows = os.platform() === 'win32';
 
 describe('tmp', function () {
   describe('#tmpNameSync()', function () {
@@ -39,12 +41,43 @@ describe('tmp', function () {
       describe('on issue #176', function () {
         const origfn = os.tmpdir;
         it('must fail on invalid os.tmpdir()', function () {
-          os.tmpdir = function () { return undefined; };
+          os.tmpdir = function () {
+            return undefined;
+          };
           try {
             tmp.tmpNameSync();
             assert.fail('should have failed');
           } catch (err) {
             assert.ok(err instanceof Error);
+          } finally {
+            os.tmpdir = origfn;
+          }
+        });
+      });
+      describe('on issue #268', function () {
+        const origfn = os.tmpdir;
+        it(`should not alter ${isWindows ? 'invalid' : 'valid'} path on os.tmpdir() returning path that includes double quotes`, function () {
+          const tmpdir = isWindows ? '"C:\\Temp With Spaces"' : '"/tmp with spaces"';
+          os.tmpdir = function () {
+            return tmpdir;
+          };
+          const name = tmp.tmpNameSync();
+          const index = name.indexOf(path.sep + tmpdir + path.sep);
+          try {
+            assert.ok(index > 0, `${tmpdir} should have been a subdirectory name in ${name}`);
+          } finally {
+            os.tmpdir = origfn;
+          }
+        });
+        it('should not alter valid path on os.tmpdir() returning path that includes single quotes', function () {
+          const tmpdir = isWindows ? '\'C:\\Temp With Spaces\'' : '\'/tmp with spaces\'';
+          os.tmpdir = function () {
+            return tmpdir;
+          };
+          const name = tmp.tmpNameSync();
+          const index = name.indexOf(path.sep + tmpdir + path.sep);
+          try {
+            assert.ok(index > 0, `${tmpdir} should have been a subdirectory name in ${name}`);
           } finally {
             os.tmpdir = origfn;
           }

--- a/test/name-sync-test.js
+++ b/test/name-sync-test.js
@@ -7,7 +7,6 @@ const
   inbandStandardTests = require('./name-inband-standard'),
   tmp = require('../lib/tmp');
 
-const isWindows = os.platform() === 'win32';
 
 describe('tmp', function () {
   describe('#tmpNameSync()', function () {
@@ -40,43 +39,12 @@ describe('tmp', function () {
       describe('on issue #176', function () {
         const origfn = os.tmpdir;
         it('must fail on invalid os.tmpdir()', function () {
-          os.tmpdir = function () {
-            return undefined;
-          };
+          os.tmpdir = function () { return undefined; };
           try {
             tmp.tmpNameSync();
             assert.fail('should have failed');
           } catch (err) {
             assert.ok(err instanceof Error);
-          } finally {
-            os.tmpdir = origfn;
-          }
-        });
-      });
-      describe('on issue #246', function () {
-        const origfn = os.tmpdir;
-        it('must produce correct name on os.tmpdir() returning path that includes double quotes', function () {
-          const tmpdir = isWindows ? '"C:\\Temp With Spaces"' : '"/tmp with spaces"';
-          os.tmpdir = function () {
-            return tmpdir;
-          };
-          const name = tmp.tmpNameSync();
-          try {
-            assert.ok(name.indexOf('"') === -1);
-            assert.ok(name.startsWith(tmpdir.replace(/["']/g, '')));
-          } finally {
-            os.tmpdir = origfn;
-          }
-        });
-        it('must produce correct name on os.tmpdir() returning path that includes single quotes', function () {
-          const tmpdir = isWindows ? '\'C:\\Temp With Spaces\'' : '\'/tmp with spaces\'';
-          os.tmpdir = function () {
-            return tmpdir;
-          };
-          const name = tmp.tmpNameSync();
-          try {
-            assert.ok(name.indexOf('\'') === -1);
-            assert.ok(name.startsWith(tmpdir.replace(/["']/g, '')));
           } finally {
             os.tmpdir = origfn;
           }

--- a/test/name-test.js
+++ b/test/name-test.js
@@ -7,7 +7,6 @@ const
   inbandStandardTests = require('./name-inband-standard'),
   tmp = require('../lib/tmp');
 
-const isWindows = os.platform() === 'win32';
 
 describe('tmp', function () {
   describe('#tmpName()', function () {
@@ -63,39 +62,6 @@ describe('tmp', function () {
           });
         });
       });
-      describe('on issue #246', function () {
-        const origfn = os.tmpdir;
-        it('must produce correct name on os.tmpdir() returning path that includes double quotes', function (done) {
-          const tmpdir = isWindows ? '"C:\\Temp With Spaces"' : '"/tmp with spaces"';
-          os.tmpdir = function () { return tmpdir; };
-          tmp.tmpName(function (err, name) {
-            try {
-              assert.ok(name.indexOf('"') === -1);
-              assert.ok(name.startsWith(tmpdir.replace(/["']/g, '')));
-            } catch (err) {
-              return done(err);
-            } finally {
-              os.tmpdir = origfn;
-            }
-            done();
-          });
-        });
-        it('must produce correct name on os.tmpdir() returning path that includes single quotes', function (done) {
-          const tmpdir = isWindows ? '\'C:\\Temp With Spaces\'' : '\'/tmp with spaces\'';
-          os.tmpdir = function () { return tmpdir; };
-          tmp.tmpName(function (err, name) {
-            try {
-              assert.ok(name.indexOf('\'') === -1);
-              assert.ok(name.startsWith(tmpdir.replace(/["']/g, '')));
-            } catch (err) {
-              return done(err);
-            } finally {
-              os.tmpdir = origfn;
-            }
-            done();
-          });
-        });
-      });
     });
 
     describe('when running standard outband tests', function () {
@@ -105,3 +71,4 @@ describe('tmp', function () {
     });
   });
 });
+


### PR DESCRIPTION
… from os.tmpdir also sanitize dir option, the template option and the name option"

This reverts commit c8823e549280e11697a510184a69b63bf5bfef7a.

Single quotes must not be removed from paths because they are valid (even if hard to use)
on all OSes. Double quotes are only disallowed on Windows, but tmp should not change any
arg it gets; instead, it should rely on the underlying fs API to fail with an error
that the user needs to fix.