### PR TITLE
Support calling remove callback multiple times

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -376,6 +376,8 @@ function _prepareRemoveCallback(removeFunction, fileOrDirName, sync, cleanupCall
       } else {
         return removeFunction(fileOrDirName, next || function() {});
       }
+    } else if (!sync) {
+      next();
     }
   };
 }

--- a/test/inband-standard.js
+++ b/test/inband-standard.js
@@ -92,8 +92,36 @@ function inbandStandardTests(testOpts, opts, isFile, beforeHook, sync = false) {
           throw err;
         }
       }.bind(topic));
+
+      it('should support removeCallback called multiple times', function () {
+        try {
+          this.topic.removeCallback();
+        } catch (err) {
+          // important: remove file or dir unconditionally
+          try {
+            fs.rmSync(this.topic.name, { recursive: true });
+          } catch (_ignored) {
+            // ignore
+          }
+          throw err;
+        }
+      }.bind(topic));
     } else {
       it('should have a working removeCallback', function (done) {
+        const self = this;
+        this.topic.removeCallback(function (err) {
+          if (err) return done(err);
+          try {
+            assertions.assertDoesNotExist(self.topic.name);
+          } catch (err) {
+            fs.rmSync(self.topic.name, { recursive: true });
+            return done(err);
+          }
+          done();
+        });
+      }.bind(topic));
+
+      it('should support removeCallback called multiple times', function (done) {
         const self = this;
         this.topic.removeCallback(function (err) {
           if (err) return done(err);


### PR DESCRIPTION
While refactoring some code, I ended up accidentally calling the remove callback multiple times. It took me way too long to figure out why it seemed like my process was hanging: because the callback passed to the remove callback isn't invoked when the remove callback is called multiple times.

I acknowledge that one shouldn't end up calling the remove callback multiple times in normal usage, but it's a big violation of expectations for my own callback to _never_ be called in that situation. I'm hoping you'll accept this patch. Thank you!