### PR TITLE
Fix use of tmp.dir() with `dir` option

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -466,7 +466,7 @@ function _resolvePath(name, tmpDir, cb) {
         cb(null, path.join(parentDir, path.basename(pathToResolve)));
       });
     } else {
-      fs.realpath(path, cb);
+      fs.realpath(pathToResolve, cb);
     }
   });
 }

--- a/test/inband-standard.js
+++ b/test/inband-standard.js
@@ -3,6 +3,7 @@
 
 var
   fs = require('fs'),
+  os = require('os'),
   path = require('path'),
   assertions = require('./assertions'),
   tmp = require('../lib/tmp');
@@ -18,6 +19,7 @@ module.exports = function inbandStandard(isFile, beforeHook, sync = false) {
   describe('with mode', inbandStandardTests(null, { mode: 0o755 }, isFile, beforeHook, sync));
   describe('with multiple options', inbandStandardTests(null, { prefix: 'tmp-multiple', postfix: 'bar', mode: 0o750 }, isFile, beforeHook, sync));
   describe('with tmpdir option', inbandStandardTests(null, { tmpdir: path.join(tmp.tmpdir, 'tmp-external'), mode: 0o750 }, isFile, beforeHook, sync));
+  describe('with dir option', inbandStandardTests(null, { dir: os.tmpdir(), mode: 0o750 }, isFile, beforeHook, sync));
   if (isFile) {
     describe('with discardDescriptor', inbandStandardTests(null, { mode: testMode, discardDescriptor: true }, isFile, beforeHook, sync));
     describe('with detachDescriptor', inbandStandardTests(null, { mode: testMode, detachDescriptor: true }, isFile, beforeHook, sync));


### PR DESCRIPTION
## Context

Passing the `dir` option to `tmp.dir()` results in a strange error:
```
> var tmp = require('./lib/tmp')
undefined
> var os = require('os')
undefined
> tmp.dir({dir: os.tmpdir()}, (err, val) => { console.log(err, val); })
undefined
> [Error: ENOENT: no such file or directory, lstat '/home/florentpro/projects/node-tmp/[object Object]'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/home/florentpro/projects/node-tmp/[object Object]'
} undefined
```

## Fix proposal

1. When reading the code, I could find that this line is the culprit (`path` is defined but refers to the `node:path` library): https://github.com/raszi/node-tmp/blob/08fa3abac32b621506512724b28b56b9c4a95846/lib/tmp.js#L469
1. When running the tests, istanbul suggests that this line is only executed 2 times, and only for errors, I add a test case to `inbandStandard` to check passing the `dir` option 

My guess is that the variable that should have been used is `pathToResolve` like in the implementation of `_resolvePathSync`:
https://github.com/raszi/node-tmp/blob/08fa3abac32b621506512724b28b56b9c4a95846/lib/tmp.js#L487

The new tests fail without the fix and pass with the fix.